### PR TITLE
Fix: 여행지 페이지 오버레이 수정

### DIFF
--- a/css/travel/index.css
+++ b/css/travel/index.css
@@ -216,7 +216,7 @@
 .popup-item img {
   width: 16px;
 }
-.popup-overlay {
+.travel-popup-overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -226,7 +226,7 @@
   z-index: 98;
   display: none;
 }
-.popup-overlay.show {
+.travel-popup-overlay.show {
   display: block;
 }
 

--- a/js/travel/pagination.js
+++ b/js/travel/pagination.js
@@ -191,7 +191,7 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   document.addEventListener("click", (e) => {
-    const overlay = document.getElementById("popupOverlay");
+    const overlay = document.getElementById("travelPopupOverlay");
 
     document.querySelectorAll(".popup").forEach((popup) => {
       popup.classList.remove("show");
@@ -207,10 +207,12 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  document.getElementById("popupOverlay").addEventListener("click", () => {
-    document.querySelectorAll(".popup").forEach((popup) => {
-      popup.classList.remove("show");
+  document
+    .getElementById("travelPopupOverlay")
+    .addEventListener("click", () => {
+      document.querySelectorAll(".popup").forEach((popup) => {
+        popup.classList.remove("show");
+      });
+      document.getElementById("travelPopupOverlay").classList.remove("show");
     });
-    document.getElementById("popupOverlay").classList.remove("show");
-  });
 });

--- a/pages/travel.html
+++ b/pages/travel.html
@@ -65,6 +65,6 @@
         </div>
       </div>
     </div>
-    <div class="popup-overlay" id="popupOverlay"></div>
+    <div class="travel-popup-overlay" id="travelPopupOverlay"></div>
   </body>
 </html>


### PR DESCRIPTION
#20 
# 여행지 페이지 오버레이 수정

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/7cc6f070-62d6-4919-89e5-1fd39bb739a7" />

- 각 아이템 우측 상단의 점 세 개 아이콘을 눌렀을 떄 표시되는 오버레이가 popup-item 까지 덮어버리는 문제 발생
- css 를 적용하는 과정에서 다른 곳에서 사용하는 overlay 와 클래스 명이 겹쳐 문제가 발생한 것으로 확인
- 변수명을 적절히 수정하여 해결