### PR TITLE
Feat: 지역 페이지 슬라이더 드래그 이벤트 추가

### DIFF
--- a/js/area/slider.js
+++ b/js/area/slider.js
@@ -239,6 +239,7 @@ document.addEventListener("DOMContentLoaded", () => {
   let startX = 0;
   let isDragging = false;
 
+  // mousedown : 드래그 시작
   sliderContainer.addEventListener("mousedown", (e) => {
     startX = e.clientX;
     isDragging = true;
@@ -247,6 +248,7 @@ document.addEventListener("DOMContentLoaded", () => {
     sliderContainer.style.transition = "none"; // 드래그 중 transition 제거
   });
 
+  // mousemove : 드래그 중
   sliderContainer.addEventListener("mousemove", (e) => {
     if (!isDragging) return;
     const diff = e.clientX - startX;
@@ -261,6 +263,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }px)`;
   });
 
+  // mouseup : 드래그 끝
   sliderContainer.addEventListener("mouseup", (e) => {
     if (!isDragging) return;
     const endX = e.clientX;

--- a/js/area/slider.js
+++ b/js/area/slider.js
@@ -235,6 +235,51 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  // 드래그 이벤트
+  let startX = 0;
+  let isDragging = false;
+
+  sliderContainer.addEventListener("mousedown", (e) => {
+    startX = e.clientX;
+    isDragging = true;
+
+    // 슬라이드 현재 위치 저장
+    sliderContainer.style.transition = "none"; // 드래그 중 transition 제거
+  });
+
+  sliderContainer.addEventListener("mousemove", (e) => {
+    if (!isDragging) return;
+    const diff = e.clientX - startX;
+    const currentTranslate =
+      sliderContainer.clientWidth / 2 -
+      slideWidth / 2 -
+      currentIndex * slideWidth;
+
+    // 슬라이더가 드래그에 따라 실시간으로 움직임
+    sliderContainer.style.transform = `translateX(${
+      currentTranslate + diff
+    }px)`;
+  });
+
+  sliderContainer.addEventListener("mouseup", (e) => {
+    if (!isDragging) return;
+    const endX = e.clientX;
+    const diff = endX - startX;
+
+    isDragging = false;
+    sliderContainer.style.transition = "transform 0.5s ease-in-out";
+
+    if (diff > 50 && currentIndex > 0) {
+      currentIndex--;
+    } else if (diff < -50 && currentIndex < totalSlides - 1) {
+      currentIndex++;
+    }
+
+    slideUpdate();
+    updateDots();
+  });
+
+  // 리사이즈 이벤트
   window.addEventListener("resize", () => {
     slideUpdate();
     currentIndex = 0;


### PR DESCRIPTION
#27 

# 지역 페이지 슬라이더 드래그 이벤트 추가
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/292685c8-a7ce-43ba-8f05-5dd4f0f462ac" />

- 마우스 down, move, up 이벤트를 감지하여 구현
- down
  - 처음 누른 마우스 위치를 저장
  - 드래그 중 애니메이션을 방지하기 위해 transition 해제
- move
  - 마우스를 얼마나 움직였는지 계산
  - 시작위치와 이벤트 위치 차이를 계산 -> diff
  - 실시간으로 translateX에 diff만큼 더해서 슬라이드가 따라오게 함
-  up
   - diff가 50px 이상이면: 왼쪽으로 스와이프한 걸로 인식 → 이전 슬라이드
   - diff가 -50px 이하이면: 오른쪽으로 스와이프 → 다음 슬라이드
   - transition 복원