### PR TITLE
Fix: 지역 페이지 초기 렌더링 수정

### DIFF
--- a/js/area/slider.js
+++ b/js/area/slider.js
@@ -289,13 +289,6 @@ document.addEventListener("DOMContentLoaded", () => {
     updateDots();
   });
 
-  // 리사이즈 이벤트
-  // window.addEventListener("resize", () => {
-  //   slideUpdate();
-  //   currentIndex = 0;
-  //   selectedUpdate();
-  //   updateDots();
-  // });
   window.addEventListener("resize", () => {
     slideUpdate(true); // transition 없이 재계산
     selectedUpdate();

--- a/js/area/slider.js
+++ b/js/area/slider.js
@@ -11,7 +11,7 @@ window.openKakaoMap = function (address) {
   window.open(url, "_blank");
 };
 
-export function slideUpdate() {
+export function slideUpdate(skipTransition = false) {
   const initialPosition = sliderContainer.clientWidth / 2 - slideWidth / 2;
 
   if (sliderData.length === 0) {
@@ -32,11 +32,17 @@ export function slideUpdate() {
   }
 
   selectedUpdate();
-  sliderContainer.style.transition = "none";
+
+  // transition 옵션에 따라 처리
+  if (skipTransition) {
+    sliderContainer.style.transition = "none";
+  } else {
+    sliderContainer.style.transition = "transform 0.5s ease-in-out";
+  }
+
   sliderContainer.style.transform = `translateX(${
     initialPosition - currentIndex * slideWidth
   }px)`;
-  sliderContainer.style.transition = "transform 0.5s ease-in-out";
 }
 
 function createDots() {
@@ -67,6 +73,7 @@ function updateDots() {
     }
   });
 }
+
 function hideBtn() {
   nextBtn = document.getElementById("sliderNextBtn");
   nextBtn.style.visibility = "hidden";
@@ -145,7 +152,7 @@ export function updateEventSlider(filteredEvents) {
     slideWidth = slides[0].offsetWidth + slideMarginRight;
   }
   currentIndex = 0;
-  slideUpdate();
+  slideUpdate(true); // transition 없이 초기 위치 설정
   createDots();
 }
 

--- a/js/area/slider.js
+++ b/js/area/slider.js
@@ -290,9 +290,14 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // 리사이즈 이벤트
+  // window.addEventListener("resize", () => {
+  //   slideUpdate();
+  //   currentIndex = 0;
+  //   selectedUpdate();
+  //   updateDots();
+  // });
   window.addEventListener("resize", () => {
-    slideUpdate();
-    currentIndex = 0;
+    slideUpdate(true); // transition 없이 재계산
     selectedUpdate();
     updateDots();
   });


### PR DESCRIPTION
#30 
# 지역 페이지 초기 렌더링 및 날짜 이동 시 슬라이더 애니메이션

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/63839270-bacd-4722-932d-c90d9329118a" />

## 주요 수정
### 초기 렌더링 시 슬라이더에 애니메니션이 적용되어, 옆에서 나타나는 모션이 있었음.
- 초기 렌더링 및 날짜 이동 시 슬라이더가 부자연스럽게 이동함
- 추가로, resize 시 focus(selected) 정보만 업데이트 되고 슬라이더는 이동하지 않았음.

### 해결 방안
- 초기 렌더링 시 및 날짜 이동 시 애니메이션 효과 제거
- resize 이벤트 수정